### PR TITLE
Update crv-basics.md - Add CRVInfo deployment address (CRV circ supply tracking contract)

### DIFF
--- a/docs/crv-token/crv-basics.md
+++ b/docs/crv-token/crv-basics.md
@@ -12,7 +12,9 @@ You can find the release schedule for the next six years at this address: [**htt
 
 # **What is the current circulating supply?**
 
-The current circulating supply can be found at this address: [**https://dao.curve.fi/inflation**](https://dao.curve.fi/inflation)​
+The current circulating supply can be found at this address: [**https://dao.curve.fi/inflation**](https://dao.curve.fi/inflation)
+
+An [**on-chain contract**](https://etherscan.io/address/0x14139EB676342b6bC8E41E0d419969f23A49881e) (`0x14139EB676342b6bC8E41E0d419969f23A49881e`) is also available to track the circulating supply, net of locked or otherwise vested tokens.
 
 # **What is the utility of CRV?**
 


### PR DESCRIPTION
Spent some time trying to look for the deployment address of https://github.com/curvefi/curve-dao-contracts/blob/master/contracts/CRVInfo.vy yesterday and figured it would be good to have it in the docs. Contract tracks the CRV circulating supply.