### PR TITLE
oracle precision warning

### DIFF
--- a/docs/factory-pools/creating-a-stableswap-ng-pool.md
+++ b/docs/factory-pools/creating-a-stableswap-ng-pool.md
@@ -43,6 +43,9 @@ Standard ERC-20 tokens do not need any additional configuration.
 
 ### **Tokens with Oracles**
 
+!!!warning "Oracle Precision"
+    The precision of the rate oracle **must be $10^{18}$**. Otherwise, the liquidity pool will not function correctly, as the exchange rate will be broken.
+
 Some tokens might require an external rate oracle to ensure correct calculations within the AMM. This is especially useful for tokens with rates against their underlying tokens, such as rETH against ETH. In this case, when selecting a token with an oracle, the corresponding box needs to be ticked, and an extra section for the contract address and oracle price method will appear. Some tokens might source their price oracle from a contract other than the token contract.
 
 <figure markdown="span">
@@ -73,7 +76,6 @@ ERC-4626 is a standard to optimize and unify the technical parameters of yield-b
   ![](../images/pool_creation/ss_erc4626_light.png#only-light){ width="400" }
   <figcaption></figcaption>
 </figure>
-
 
 
 ---


### PR DESCRIPTION
add oracle precision warning when using rate oracle in stableswap-ng pools